### PR TITLE
Make per page options configurable.

### DIFF
--- a/config/nova.php
+++ b/config/nova.php
@@ -91,4 +91,17 @@ return [
 
     'pagination' => 'simple',
 
+    /*
+    |--------------------------------------------------------------------------
+    | Nova Per Page Options
+    |--------------------------------------------------------------------------
+    |
+    | This option defines the records per page options used by Resources.
+    | You may customize the global default per page options here. You
+    | may override these defaults on a per-resource basis as well.
+    |
+    */
+
+    'perPageOptions' => [25, 50, 100],
+
 ];

--- a/config/nova.php
+++ b/config/nova.php
@@ -102,6 +102,6 @@ return [
     |
     */
 
-    'perPageOptions' => [25, 50, 100],
+    'per_page_options' => [25, 50, 100],
 
 ];

--- a/tests/Browser/IndexTest.php
+++ b/tests/Browser/IndexTest.php
@@ -195,6 +195,27 @@ class IndexTest extends DuskTestCase
     /**
      * @test
      */
+    public function number_of_resources_displayed_per_page_matches_config()
+    {
+        factory(User::class, 50)->create();
+
+        $this->browse(function (Browser $browser) {
+            $browser->loginAs(User::find(1))
+                    ->visit(new Pages\UserIndex)
+                    ->within(new IndexComponent('users'), function ($browser) {
+                        $browser->setPerPage('50')
+                                ->within('@per-page-select', function ($browser) {
+                                    $browser->assertSeeIn('option:nth-of-type(1)', '25')
+                                            ->assertSeeIn('option:nth-of-type(2)', '50')
+                                            ->assertSeeIn('option:nth-of-type(3)', '100');
+                                });
+                    });
+        });
+    }
+
+    /**
+     * @test
+     */
     public function number_of_resources_displayed_per_page_can_be_changed()
     {
         factory(User::class, 50)->create();


### PR DESCRIPTION
Companion PR to laravel/nova/pull/362.

The new `number_of_resources_displayed_per_page_matches_config` test in `IndexTest.php` uses `within` and `assertSeeIn` since the `assertSelectHasOptions` method only accepts a name or id selector and doesn't work with dusk selectors. Ideally, I would have used:

```js
$brower->assertSelectHasOptions('@per-page-select', [25, 50, 100]);
```