### PR TITLE
Add tests for BelongsTo relation with Inline Relation Button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ yarn-error.log
 .env
 .searchable
 .inline-create
+.index-query-asc-order
 
 /public/vendor/nova/*
 /resources/lang/vendor/nova/*

--- a/app/Nova/Resource.php
+++ b/app/Nova/Resource.php
@@ -15,6 +15,23 @@ abstract class Resource extends NovaResource
     public static $trafficCop = false;
 
     /**
+     * Build an "index" query for the given resource.
+     *
+     * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request
+     * @param  \Illuminate\Database\Eloquent\Builder  $query
+     * @return \Illuminate\Database\Eloquent\Builder
+     */
+    public static function indexQuery(NovaRequest $request, $query)
+    {
+
+        if (file_exists(base_path('.index-query-asc-order'))) {
+            $query->reorder('id', 'asc');
+        }
+
+        return $query;
+    }
+
+    /**
      * Build a "detail" query for the given resource.
      *
      * @param  \Laravel\Nova\Http\Requests\NovaRequest  $request

--- a/app/Nova/Sail.php
+++ b/app/Nova/Sail.php
@@ -35,7 +35,10 @@ class Sail extends Resource
     {
         return [
             ID::make('ID', 'id')->sortable(),
-            BelongsTo::make('Ship', 'ship')->display('name'),
+            BelongsTo::make('Ship', 'ship')
+                ->display('name')
+                ->showCreateRelationButton(file_exists(base_path('.inline-create')))
+                ->searchable(file_exists(base_path('.searchable'))),
             Number::make('Inches', 'inches')->sortable(),
         ];
     }

--- a/app/Nova/Ship.php
+++ b/app/Nova/Ship.php
@@ -29,6 +29,8 @@ class Ship extends Resource
         'id', 'name',
     ];
 
+    public static $relatableSearchResults = 5;
+
     /**
      * Get the fields displayed by the resource.
      *

--- a/tests/Browser/CreateWithInlineRelationButtonTest.php
+++ b/tests/Browser/CreateWithInlineRelationButtonTest.php
@@ -4,13 +4,47 @@ namespace Laravel\Nova\Tests\Browser;
 
 use App\Models\Comment;
 use App\Models\User;
+use Database\Factories\DockFactory;
 use Database\Factories\PostFactory;
+use Database\Factories\ShipFactory;
 use Laravel\Dusk\Browser;
 use Laravel\Nova\Testing\Browser\Pages\Create;
 use Laravel\Nova\Tests\DuskTestCase;
 
 class CreateWithInlineRelationButtonTest extends DuskTestCase
 {
+    /**
+     * @test
+     */
+    public function belongs_to_resource_should_fetch_the_related_resource_id_info()
+    {
+        $this->whileIndexQueryAscOrder(function () {
+            $this->whileInlineCreate(function () {
+                $this->whileSearchable(function () {
+
+                    $dock = DockFactory::new()->create();
+                    $ships = ShipFactory::new()->count(5)->create();
+
+                    $this->browse(function (Browser $browser) use ($dock) {
+                        $browser->loginAs(User::find(1))
+                            ->visit(new Create('sails'))
+                            ->runInlineCreate('ship', function ($browser) use ($dock) {
+                                $browser->waitForText('Create Ship', 25)
+                                    ->searchAndSelectFirstRelation('docks', $dock->id)
+                                    ->type('@name', 'Ship name');
+                            })
+                            ->waitForText('The ship was created!', 25)
+                            ->pause(500)
+                            ->assertSee('Ship name')
+                            ->type('@inches', 25)
+                            ->create()
+                            ->waitForText('The sail was created!', 25);
+                    });
+                });
+            });
+        });
+    }
+
     /**
      * @test
      */

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -197,6 +197,17 @@ abstract class DuskTestCase extends \Orchestra\Testbench\Dusk\TestCase
         }
     }
 
+    protected function whileIndexQueryAscOrder(callable $callback)
+    {
+        touch(base_path('.index-query-asc-order'));
+
+        try {
+            $callback();
+        } finally {
+            @unlink(base_path('.index-query-asc-order'));
+        }
+    }
+
     /**
      * Create a new Browser instance.
      *


### PR DESCRIPTION
tests for https://github.com/laravel/nova/pull/1180

Test will fail when all the below is:
- `BelongsTo` is searchable
- `BelongsTo` has `$relatableSearchResults` limit (e.g: 5)
- `indexQuery` has a different order.

currently after creating a resource from "Inline Relation Button" BelongsTo field will fetch again the resources (last 5 results) instead of fetching the selected resource id.

